### PR TITLE
Add few bugfixes for Version Parser for 0,0,0

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -67,6 +67,7 @@ func deamon(wg *sync.WaitGroup, crawlerDB, nodeDB *sql.DB) {
 			if err != nil {
 				fmt.Printf("Error inserting nodes: %v\n", err)
 			}
+			fmt.Printf("%d nodes inserted\n", len(nodes))
 		}
 		time.Sleep(time.Second)
 	}

--- a/api/parser/vparser.go
+++ b/api/parser/vparser.go
@@ -120,25 +120,25 @@ func parseVersion(input string) Version {
 }
 
 func parseVersionNumber(input string) (int, int, int) {
-		// Version
-		trimmed := strings.TrimLeft(input, "v")
-		vSplit := strings.Split(trimmed, ".")
-		var major, minor, patch int
+	// Version
+	trimmed := strings.TrimLeft(input, "v")
+	vSplit := strings.Split(trimmed, ".")
+	var major, minor, patch int
 
-		switch len(vSplit) {
-		case 4:
-			fallthrough
-		case 3:
-			patch, _ = strconv.Atoi(vSplit[2])
-			fallthrough
-		case 2:
-			minor, _ = strconv.Atoi(vSplit[1])
-			fallthrough
-		case 1:
-			major, _ = strconv.Atoi(vSplit[0])
-		}
+	switch len(vSplit) {
+	case 4:
+		fallthrough
+	case 3:
+		patch, _ = strconv.Atoi(vSplit[2])
+		fallthrough
+	case 2:
+		minor, _ = strconv.Atoi(vSplit[1])
+		fallthrough
+	case 1:
+		major, _ = strconv.Atoi(vSplit[0])
+	}
 
-		return major, minor, patch
+	return major, minor, patch
 }
 
 func parseOS(input string) OSInfo {

--- a/api/parser/vparser.go
+++ b/api/parser/vparser.go
@@ -45,12 +45,12 @@ func ParseVersionString(input string) ParsedInfo {
 	// version string consists of four components, divided by /
 	s := strings.Split(strings.ToLower(input), "/")
 	l := len(s)
-	output.Name = s[0]
+	output.Name = strings.ToLower(s[0])
 	if output.Name == "" {
-		output.Name = "unknown"
+		output.Name = "tmp"
 	}
 
-	if l == 5 {
+	if l == 5 || l == 7 {
 		output.Label = s[1]
 		output.Version = parseVersion(s[2])
 		output.Os = parseOS(s[3])
@@ -59,6 +59,10 @@ func ParseVersionString(input string) ParsedInfo {
 		output.Version = parseVersion(s[1])
 		output.Os = parseOS(s[2])
 		output.Language = parseLanguage(s[3])
+	} else if (l == 1 || l == 0) && (output.Name == "tmp" || output.Name == "eth2") {
+		// These are usually "tmp" nodes that cannot be parsed.
+	} else {
+		fmt.Printf("Parser Error: Invalid length of '%d' for input: '%s'\n", l, input)
 	}
 	return output
 }
@@ -78,7 +82,19 @@ func parseLanguage(input string) LanguageInfo {
 func parseVersion(input string) Version {
 	var vers Version
 	split := strings.Split(input, "-")
+	split_length := len(split)
 	switch len(split) {
+	case 8:
+		fallthrough
+	case 7:
+		fallthrough
+	case 6:
+		fallthrough
+	case 5:
+		vers.Date = split[split_length - 1]
+		vers.Build = split[split_length - 2]
+		vers.Tag = strings.Join(split[1:split_length - 3], "")
+		vers.Major, vers.Minor, vers.Patch = parseVersionNumber(split[0])
 	case 4:
 		// Date
 		vers.Date = split[3]
@@ -93,16 +109,36 @@ func parseVersion(input string) Version {
 		fallthrough
 	case 1:
 		// Version
-		trimmed := strings.TrimLeft(split[0], "v")
-		vSplit := strings.Split(trimmed, ".")
-		if len(vSplit) != 3 {
-			break
-		}
-		vers.Major, _ = strconv.Atoi(vSplit[0])
-		vers.Minor, _ = strconv.Atoi(vSplit[1])
-		vers.Patch, _ = strconv.Atoi(vSplit[2])
+		vers.Major, vers.Minor, vers.Patch = parseVersionNumber(split[0])
 	}
+
+	if vers.Major == 0 && vers.Minor == 0 && vers.Patch == 0 {
+		fmt.Println(len(split), "Version string is invalid:", input)
+	}
+	
 	return vers
+}
+
+func parseVersionNumber(input string) (int, int, int) {
+		// Version
+		trimmed := strings.TrimLeft(input, "v")
+		vSplit := strings.Split(trimmed, ".")
+		var major, minor, patch int
+
+		switch len(vSplit) {
+		case 4:
+			fallthrough
+		case 3:
+			patch, _ = strconv.Atoi(vSplit[2])
+			fallthrough
+		case 2:
+			minor, _ = strconv.Atoi(vSplit[1])
+			fallthrough
+		case 1:
+			major, _ = strconv.Atoi(vSplit[0])
+		}
+
+		return major, minor, patch
 }
 
 func parseOS(input string) OSInfo {


### PR DESCRIPTION
When a version isn't parsed, print it to the console so it is easier to do incremental updates, and support more client names.