### PR TITLE
Remove typo from crawler 's Dockerfile

### DIFF
--- a/docker/crawler/Dockerfile
+++ b/docker/crawler/Dockerfile
@@ -1,4 +1,4 @@
-/# Compile crawler 
+# Compile crawler 
 FROM golang:1.16-alpine AS go_builder
 RUN apk add gcc musl-dev linux-headers git
 RUN git clone https://github.com/ethereum/node-crawler.git


### PR DESCRIPTION
## Description
A typo was inserted 7 months into the `crawler/Dockerfile` when updating the dependencies -> leading  `docker-compose up` to crash.
 
This PR removes the typo and makes the `docker-compose` run again. 