### PR TITLE
Nix service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ nodes
 node-crawler-backend.exe
 node-crawler-backend
 /data/
+
+# nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -19,21 +19,21 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems_2"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "lastModified": 1693611461,
+        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -53,13 +53,31 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1693471703,
+        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1692808169,
-        "narHash": "sha256-x9Opq06rIiwdwGeK2Ykj69dNc2IvUH1fY55Wm7atwrE=",
+        "lastModified": 1693594656,
+        "narHash": "sha256-JgUQkso4tbQDaE5SJic/EDDrehAQ/xoOSGCuakGE6OM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9201b5ff357e781bf014d0330d18555695df7ba8",
+        "rev": "cdceca7fb009a8ca0b7c4539f00b106ed21e86dc",
         "type": "github"
       },
       "original": {
@@ -72,26 +90,11 @@
     "root": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692793255,
-        "narHash": "sha256-yVyj0AE280JkccDHuG1XO9oGxN6bW8ksr/xttXcXzK0=",
+        "lastModified": 1694435990,
+        "narHash": "sha256-yLQPD2eZGepu3yvdwABXrR3GhAqWRWTj9rn3a4knYuk=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "2aa26972b951bc05c3632d4e5ae683cb6771a7c6",
+        "rev": "f6aec2e8b1cdddcab10ce7fc2eac66886e3deaad",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1693594656,
-        "narHash": "sha256-JgUQkso4tbQDaE5SJic/EDDrehAQ/xoOSGCuakGE6OM=",
+        "lastModified": 1694343207,
+        "narHash": "sha256-jWi7OwFxU5Owi4k2JmiL1sa/OuBCQtpaAesuj5LXC8w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cdceca7fb009a8ca0b7c4539f00b106ed21e86dc",
+        "rev": "78058d810644f5ed276804ce7ea9e82d92bee293",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,19 +4,31 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     devshell.url = "github:numtide/devshell";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs = { self, nixpkgs, devshell, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ devshell.overlays.default ];
+  outputs = inputs@{ self, nixpkgs, devshell, flake-parts }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [
+        devshell.flakeModule
+        flake-parts.flakeModules.easyOverlay
+      ];
+
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem = { config, pkgs, final, ... }: {
+        overlayAttrs = {
+          inherit (config.packages) nodeCrawler;
+          inherit (config.packages) nodeCrawlerFrontend;
         };
-      in {
+
         packages = {
-          crawler = pkgs.buildGoModule rec {
+          nodeCrawler = pkgs.buildGoModule rec {
             pname = "crawler";
             version = "0.0.0";
 
@@ -35,15 +47,232 @@
               "-extldflags -static"
             ];
           };
+          nodeCrawlerFrontend = pkgs.buildNpmPackage rec {
+            pname = "frontend";
+            version = "0.0.0";
+
+            src = ./frontend;
+
+            npmDepsHash = "sha256-1nLQVoNkiA4x97UcPe8rNMXa7bYCskazpJesWVLnDHk=";
+
+            installPhase = ''
+              mkdir -p $out/share
+              cp -r build/ $out/share/frontend
+            '';
+          };
         };
-        devShell = pkgs.devshell.mkShell {
+
+        devshells.default = {
           packages = with pkgs; [
             go
-            gopls
             golangci-lint
+            nodejs
             sqlite
           ];
         };
-      });
-}
+      };
 
+      flake = rec {
+        nixosModules.default = nixosModules.nodeCrawler;
+        nixosModules.nodeCrawler = { config, lib, pkgs, ... }:
+        with lib;
+        let
+          cfg = config.services.nodeCrawler;
+          apiAddress = "${cfg.api.address}:${toString cfg.api.port}";
+        in
+        {
+          options.services.nodeCrawler = {
+            enable = mkEnableOption (self.flake.description);
+
+            hostName = mkOption {
+              type = types.str;
+              default = "localhost";
+              description = "Hostname to serve Node Crawler on.";
+            };
+
+            nginx = mkOption {
+              type = types.attrs;
+              default = { };
+              example = literalExpression ''
+                {
+                  forceSSL = true;
+                  enableACME = true;
+                }
+              '';
+              description = "Extra configuration for the vhost. Useful for adding SSL settings.";
+            };
+
+            stateDir = mkOption {
+              type = types.path;
+              default = /var/lib/node_crawler;
+              description = "Directory where the databases will exist.";
+            };
+
+            crawlerDatabaseName = mkOption {
+              type = types.str;
+              default = "crawler.db";
+              description = "Name of the file within the `stateDir` for storing the data for the crawler.";
+            };
+
+            apiDatabaseName = mkOption {
+              type = types.str;
+              default = "api.db";
+              description = "Name of the file within the `stateDir` for storing the data for the API.";
+            };
+
+            user = mkOption {
+              type = types.str;
+              default = "nodecrawler";
+              description = "User account under which Node Crawler runs.";
+            };
+
+            group = mkOption {
+              type = types.str;
+              default = "nodecrawler";
+              description = "Group account under which Node Crawler runs.";
+            };
+
+            dynamicUser = mkOption {
+              type = types.bool;
+              default = true;
+              description = ''
+                Runs the Node Crawler as a SystemD DynamicUser.
+                It means SystenD will allocate the user at runtime, and enables
+                some other security features.
+                If you are not sure what this means, it's safe to leave it default.
+              '';
+            };
+
+            api = {
+              enable = mkOption {
+                default = true;
+                type = types.bool;
+                description = "Enables the Node Crawler API server.";
+              };
+
+              address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = "Listen address for the API server.";
+              };
+
+              port = mkOption {
+                type = types.port;
+                default = 10000;
+                description = "Listen port for the API server.";
+              };
+            };
+
+            crawler = {
+              enable = mkOption {
+                default = true;
+                type = types.bool;
+                description = "Enables the Node Crawler API server.";
+              };
+
+              geoipdb = mkOption {
+                type = types.path;
+                default = config.services.geoipupdate.settings.DatabaseDirectory + "/GeoLite2-Country.mmdb";
+                description = ''
+                  Location of the GeoIP database.
+
+                  If the default is used, the `geoipupdate` service files.
+                  So you will need to configure it.
+                  Make sure to enable the `GeoLite2-Country` edition.
+
+                  If you do not want to enable the `geoipupdate` service, then
+                  the `GeoLite2-Country` file needs to be provided.
+                '';
+              };
+
+              network = {
+                type = types.str;
+                default = "mainnet";
+                example = "goerli";
+                description = "Name of the network to crawl. Defaults to Mainnet.";
+              };
+            };
+          };
+
+          config = mkIf cfg.enable {
+            systemd.services = {
+              node-crawler-crawler = {
+                description = "Node Cralwer, the Ethereum Node Crawler.";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "network.target" ];
+
+                serviceConfig = {
+                  ExecStart =
+                  let
+                    args = [
+                      "--crawler-db=${cfg.crawlerDatabaseName}"
+                      "--geoipdb=${cfg.crawler.geoipdb}"
+                    ]
+                    ++ optional (cfg.crawler.network == "goerli") "--goerli"
+                    ++ optional (cfg.crawler.network == "sepolia") "--sepolia";
+                  in
+                  "${pkgs.nodeCrawler}/bin/crawler crawl ${concatStringsSep " " args}";
+
+                  WorkingDirectory = cfg.stateDir;
+                  StateDirectory = optional (cfg.stateDir == /var/lib/node_crawler) "node_crawler";
+
+                  DynamicUser = cfg.dynamicUser;
+                  Group = cfg.group;
+                  User = cfg.user;
+
+                  Restart = "on-failure";
+                };
+              };
+              node-crawler-api = {
+                description = "Node Cralwer API, the API for the Ethereum Node Crawler.";
+                wantedBy = [ "multi-user.target" ];
+                after = [ "network.target" ]
+                  ++ optional cfg.crawler.enable "node-crawler-crawler.service";
+
+                serviceConfig = {
+                  ExecStart =
+                  let
+                    args = [
+                      "--addr=${apiAddress}"
+                      "--crawler-db=${cfg.crawlerDatabaseName}"
+                      "--api-db=${cfg.apiDatabaseName}"
+                    ];
+                  in
+                  "${pkgs.nodeCrawler}/bin/crawler api ${concatStringsSep " " args}";
+
+                  WorkingDirectory = cfg.stateDir;
+                  StateDirectory = optional (cfg.stateDir == /var/lib/node_crawler) "node_crawler";
+
+                  DynamicUser = cfg.dynamicUser;
+                  Group = cfg.group;
+                  User = cfg.user;
+
+                  Restart = "on-failure";
+                };
+              };
+            };
+
+            services.nginx = {
+              enable = true;
+              upstreams.nodeCrawlerApi.servers."${apiAddress}" = { };
+              virtualHosts."${cfg.hostName}" = mkMerge [
+                cfg.nginx
+                {
+                  root = mkForce "${pkgs.nodeCrawlerFrontend}/share/frontend";
+                  locations = {
+                    "/" = {
+                      index = "index.html";
+                      tryFiles = "$uri $uri/ /index.html";
+                    };
+                    "/v1/" = {
+                      proxyPass = "http://nodeCrawlerApi/v1/";
+                    };
+                  };
+                }
+              ];
+            };
+          };
+        };
+      };
+  };
+}


### PR DESCRIPTION
This configuration allows us to deploy the service on NixOS.

The `flake.nix` is getting a bit large. The standard is to add a `/nix` directory, and split out various parts of the configuration into separate files. I can do that now if we think it is a good idea. I didn't want to pollute the root of the project with yet another file. This shouldn't be something which is changed often, so I'm not so worried about a giant file.

I have this config deployed to my own NixOS server: https://node-crawler.s3fe.io/
I will keep this updated whenever I make changes for testing.