### PR TITLE
Add autovacuum and busy timeout parameters to sqlite

### DIFF
--- a/cmd/crawler/crawlercmd.go
+++ b/cmd/crawler/crawlercmd.go
@@ -42,19 +42,21 @@ var (
 		Usage:  "Crawl the ethereum network",
 		Action: crawlNodes,
 		Flags: []cli.Flag{
-			utils.GoerliFlag,
-			utils.SepoliaFlag,
-			utils.NetworkIdFlag,
+			&autovacuumFlag,
 			&bootnodesFlag,
-			&nodeURLFlag,
-			&nodeFileFlag,
-			&timeoutFlag,
+			&busyTimeoutFlag,
 			&crawlerDBFlag,
-			&listenAddrFlag,
-			&nodekeyFlag,
-			&nodedbFlag,
 			&geoipdbFlag,
+			&listenAddrFlag,
+			&nodeFileFlag,
+			&nodeURLFlag,
+			&nodedbFlag,
+			&nodekeyFlag,
+			&timeoutFlag,
 			&workersFlag,
+			utils.GoerliFlag,
+			utils.NetworkIdFlag,
+			utils.SepoliaFlag,
 		},
 	}
 	bootnodesFlag = cli.StringSliceFlag{
@@ -118,7 +120,13 @@ func crawlNodes(ctx *cli.Context) error {
 			shouldInit = true
 		}
 		var err error
-		if db, err = sql.Open("sqlite", name); err != nil {
+
+		db, err = openSQLiteDB(
+			name,
+			ctx.String(autovacuumFlag.Name),
+			ctx.Uint64(busyTimeoutFlag.Name),
+		)
+		if err != nil {
 			panic(err)
 		}
 		log.Info("Connected to db")

--- a/cmd/crawler/flags.go
+++ b/cmd/crawler/flags.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	autovacuumFlag = cli.StringFlag{
+		Name: "autovacuum",
+		Usage: ("Sets the autovacuum value for the databases. Possible values: " +
+			"NONE, FULL, or INCREMENTAL. " +
+			"https://www.sqlite.org/pragma.html#pragma_auto_vacuum"),
+		Value: "INCREMENTAL",
+	}
+	busyTimeoutFlag = cli.Uint64Flag{
+		Name: "busy-timeout",
+		Usage: ("Sets the busy_timeout value for the database in milliseconds. " +
+			"https://www.sqlite.org/pragma.html#pragma_busy_timeout"),
+		Value: 3000,
+	}
+)

--- a/cmd/crawler/setup.go
+++ b/cmd/crawler/setup.go
@@ -77,18 +77,18 @@ var (
 
 // Flags holds all command-line flags required for debugging.
 var Flags = []cli.Flag{
-	&verbosityFlag,
-	&vmoduleFlag,
-	&logjsonFlag,
 	&backtraceAtFlag,
-	&debugFlag,
-	&pprofFlag,
-	&pprofAddrFlag,
-	&pprofPortFlag,
-	&memprofilerateFlag,
 	&blockprofilerateFlag,
 	&cpuprofileFlag,
+	&debugFlag,
+	&logjsonFlag,
+	&memprofilerateFlag,
+	&pprofAddrFlag,
+	&pprofFlag,
+	&pprofPortFlag,
 	&traceFlag,
+	&verbosityFlag,
+	&vmoduleFlag,
 }
 
 var glogger *log.GlogHandler

--- a/cmd/crawler/utils.go
+++ b/cmd/crawler/utils.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func openSQLiteDB(
+	name,
+	autovacuum string,
+	busyTimeout uint64,
+) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", name)
+	if err != nil {
+		return nil, fmt.Errorf("error opening database: %w", err)
+	}
+	_, err = db.Exec("PRAGMA auto_vacuum = " + autovacuum)
+	if err != nil {
+		return nil, fmt.Errorf("error setting auto_vacuum: %w", err)
+	}
+	_, err = db.Exec(fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeout))
+	if err != nil {
+		return nil, fmt.Errorf("error setting busy_timeout: %w", err)
+	}
+
+	return db, nil
+}


### PR DESCRIPTION
I added the function `openSQLiteDB` so that we could add support for autovacuum to keep file sizes small after deleting/updating a lot of rows, and `busy_timeout` so we don't get errors when copying data from the crawler sqlite database to the api database.

I added two new flags, with sensible defaults:
 - `autovacuum`
 - `busy-timeout`

The docs for each of these features are given with the CLI flag.