### PR TITLE
Crawler table cleanup

### DIFF
--- a/cmd/crawler/api.go
+++ b/cmd/crawler/api.go
@@ -28,21 +28,6 @@ var (
 			&dropNodesTimeFlag,
 		},
 	}
-	crawlerDBFlag = cli.StringFlag{
-		Name:     "crawler-db",
-		Usage:    "Crawler SQLite file name",
-		Required: true,
-	}
-	apiDBFlag = cli.StringFlag{
-		Name:     "api-db",
-		Usage:    "API SQLite file name",
-		Required: true,
-	}
-	dropNodesTimeFlag = cli.DurationFlag{
-		Name:  "drop-time",
-		Usage: "Time to drop crawled nodes without any updates",
-		Value: 24 * time.Hour,
-	}
 )
 
 func startAPI(ctx *cli.Context) error {

--- a/cmd/crawler/crawlercmd.go
+++ b/cmd/crawler/crawlercmd.go
@@ -19,7 +19,6 @@ package main
 import (
 	"database/sql"
 	"os"
-	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -58,47 +57,6 @@ var (
 			utils.NetworkIdFlag,
 			utils.SepoliaFlag,
 		},
-	}
-	bootnodesFlag = cli.StringSliceFlag{
-		Name: "bootnodes",
-		Usage: ("Comma separated nodes used for bootstrapping. " +
-			"Defaults to hard-coded values for the selected network"),
-	}
-	nodeURLFlag = cli.StringFlag{
-		Name:  "nodeURL",
-		Usage: "URL of the node you want to connect to",
-		// Value: "http://localhost:8545",
-	}
-	nodeFileFlag = cli.StringFlag{
-		Name:  "nodefile",
-		Usage: "Path to a node file containing nodes to be crawled",
-	}
-	timeoutFlag = cli.DurationFlag{
-		Name:  "timeout",
-		Usage: "Timeout for the crawling in a round",
-		Value: 5 * time.Minute,
-	}
-	listenAddrFlag = cli.StringFlag{
-		Name:  "addr",
-		Usage: "Listening address",
-		Value: "0.0.0.0:0",
-	}
-	nodekeyFlag = cli.StringFlag{
-		Name:  "nodekey",
-		Usage: "Hex-encoded node key",
-	}
-	nodedbFlag = cli.StringFlag{
-		Name:  "nodedb",
-		Usage: "Nodes database location. Defaults to in memory database",
-	}
-	geoipdbFlag = cli.StringFlag{
-		Name:  "geoipdb",
-		Usage: "geoip2 database location",
-	}
-	workersFlag = cli.Uint64Flag{
-		Name:  "workers",
-		Usage: "Number of workers to start for updating nodes",
-		Value: 16,
 	}
 )
 

--- a/cmd/crawler/crawlercmd.go
+++ b/cmd/crawler/crawlercmd.go
@@ -42,19 +42,21 @@ var (
 		Usage:  "Crawl the ethereum network",
 		Action: crawlNodes,
 		Flags: []cli.Flag{
-			utils.GoerliFlag,
-			utils.SepoliaFlag,
-			utils.NetworkIdFlag,
+			&autovacuumFlag,
 			&bootnodesFlag,
-			&nodeURLFlag,
-			&nodeFileFlag,
-			&timeoutFlag,
+			&busyTimeoutFlag,
 			&crawlerDBFlag,
-			&listenAddrFlag,
-			&nodekeyFlag,
-			&nodedbFlag,
 			&geoipdbFlag,
+			&listenAddrFlag,
+			&nodeFileFlag,
+			&nodeURLFlag,
+			&nodedbFlag,
+			&nodekeyFlag,
+			&timeoutFlag,
 			&workersFlag,
+			utils.GoerliFlag,
+			utils.NetworkIdFlag,
+			utils.SepoliaFlag,
 		},
 	}
 	bootnodesFlag = cli.StringSliceFlag{
@@ -118,7 +120,13 @@ func crawlNodes(ctx *cli.Context) error {
 			shouldInit = true
 		}
 		var err error
-		if db, err = sql.Open("sqlite", name); err != nil {
+
+		db, err = openSQLiteDB(
+			name,
+			ctx.String(autovacuumFlag.Name),
+			ctx.Uint64(busyTimeoutFlag.Name),
+		)
+		if err != nil {
 			panic(err)
 		}
 		log.Info("Connected to db")

--- a/cmd/crawler/flags.go
+++ b/cmd/crawler/flags.go
@@ -1,10 +1,22 @@
 package main
 
 import (
+	"time"
+
 	"github.com/urfave/cli/v2"
 )
 
 var (
+	apiDBFlag = cli.StringFlag{
+		Name:     "api-db",
+		Usage:    "API SQLite file name",
+		Required: true,
+	}
+	apiListenAddrFlag = cli.StringFlag{
+		Name:  "addr",
+		Usage: "Listening address",
+		Value: "0.0.0.0:10000",
+	}
 	autovacuumFlag = cli.StringFlag{
 		Name: "autovacuum",
 		Usage: ("Sets the autovacuum value for the databases. Possible values: " +
@@ -12,10 +24,61 @@ var (
 			"https://www.sqlite.org/pragma.html#pragma_auto_vacuum"),
 		Value: "INCREMENTAL",
 	}
+	bootnodesFlag = cli.StringSliceFlag{
+		Name: "bootnodes",
+		Usage: ("Comma separated nodes used for bootstrapping. " +
+			"Defaults to hard-coded values for the selected network"),
+	}
 	busyTimeoutFlag = cli.Uint64Flag{
 		Name: "busy-timeout",
 		Usage: ("Sets the busy_timeout value for the database in milliseconds. " +
 			"https://www.sqlite.org/pragma.html#pragma_busy_timeout"),
 		Value: 3000,
+	}
+	crawlerDBFlag = cli.StringFlag{
+		Name:     "crawler-db",
+		Usage:    "Crawler SQLite file name",
+		Required: true,
+	}
+	dropNodesTimeFlag = cli.DurationFlag{
+		Name:  "drop-time",
+		Usage: "Time to drop crawled nodes without any updates",
+		Value: 24 * time.Hour,
+	}
+	geoipdbFlag = cli.StringFlag{
+		Name:  "geoipdb",
+		Usage: "geoip2 database location",
+	}
+	listenAddrFlag = cli.StringFlag{
+		Name:  "addr",
+		Usage: "Listening address",
+		Value: "0.0.0.0:0",
+	}
+	nodedbFlag = cli.StringFlag{
+		Name:  "nodedb",
+		Usage: "Nodes database location. Defaults to in memory database",
+	}
+	nodeFileFlag = cli.StringFlag{
+		Name:  "nodefile",
+		Usage: "Path to a node file containing nodes to be crawled",
+	}
+	nodekeyFlag = cli.StringFlag{
+		Name:  "nodekey",
+		Usage: "Hex-encoded node key",
+	}
+	nodeURLFlag = cli.StringFlag{
+		Name:  "nodeURL",
+		Usage: "URL of the node you want to connect to",
+		// Value: "http://localhost:8545",
+	}
+	timeoutFlag = cli.DurationFlag{
+		Name:  "timeout",
+		Usage: "Timeout for the crawling in a round",
+		Value: 5 * time.Minute,
+	}
+	workersFlag = cli.Uint64Flag{
+		Name:  "workers",
+		Usage: "Number of workers to start for updating nodes",
+		Value: 16,
 	}
 )

--- a/cmd/crawler/flags.go
+++ b/cmd/crawler/flags.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	autovacuumFlag = cli.StringFlag{
+		Name: "autovacuum",
+		Usage: ("Sets the autovacuum value for the databases. Possible values: " +
+			"NONE, FULL, or INCREMENTAL. " +
+			"https://www.sqlite.org/pragma.html#pragma_auto_vacuum"),
+		Value: "INCREMENTAL",
+	}
+	busyTimeoutFlag = cli.Uint64Flag{
+		Name: "busy-timeout",
+		Usage: ("Sets the busy_timeout value for the database in milliseconds. " +
+			"https://www.sqlite.org/pragma.html#pragma_busy_timeout"),
+		Value: 3000,
+	}
+)

--- a/cmd/crawler/setup.go
+++ b/cmd/crawler/setup.go
@@ -77,18 +77,18 @@ var (
 
 // Flags holds all command-line flags required for debugging.
 var Flags = []cli.Flag{
-	&verbosityFlag,
-	&vmoduleFlag,
-	&logjsonFlag,
 	&backtraceAtFlag,
-	&debugFlag,
-	&pprofFlag,
-	&pprofAddrFlag,
-	&pprofPortFlag,
-	&memprofilerateFlag,
 	&blockprofilerateFlag,
 	&cpuprofileFlag,
+	&debugFlag,
+	&logjsonFlag,
+	&memprofilerateFlag,
+	&pprofAddrFlag,
+	&pprofFlag,
+	&pprofPortFlag,
 	&traceFlag,
+	&verbosityFlag,
+	&vmoduleFlag,
 }
 
 var glogger *log.GlogHandler

--- a/cmd/crawler/utils.go
+++ b/cmd/crawler/utils.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+func openSQLiteDB(
+	name,
+	autovacuum string,
+	busyTimeout uint64,
+) (*sql.DB, error) {
+	db, err := sql.Open("sqlite", name)
+	if err != nil {
+		return nil, fmt.Errorf("error opening database: %w", err)
+	}
+	_, err = db.Exec("PRAGMA auto_vacuum = " + autovacuum)
+	if err != nil {
+		return nil, fmt.Errorf("error setting auto_vacuum: %w", err)
+	}
+	_, err = db.Exec(fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeout))
+	if err != nil {
+		return nil, fmt.Errorf("error setting busy_timeout: %w", err)
+	}
+
+	return db, nil
+}

--- a/pkg/apidb/database.go
+++ b/pkg/apidb/database.go
@@ -3,6 +3,8 @@ package apidb
 import (
 	"database/sql"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/ethereum/node-crawler/pkg/crawlerdb"
@@ -83,6 +85,13 @@ func InsertCrawledNodes(db *sql.DB, crawledNodes []crawlerdb.CrawledNode) error 
 	if err != nil {
 		return err
 	}
+
+	// It's possible for us to have the same node scraped multiple times, so
+	// we want to make sure when we are upserting, we get the most recent
+	// scrape upserted last.
+	sort.SliceStable(crawledNodes, func(i, j int) bool {
+		return strings.Compare(crawledNodes[i].Now, crawledNodes[j].Now) < 0
+	})
 
 	for _, node := range crawledNodes {
 		parsed := vparser.ParseVersionString(node.ClientType)

--- a/pkg/crawlerdb/crawlerdb.go
+++ b/pkg/crawlerdb/crawlerdb.go
@@ -2,7 +2,6 @@ package crawlerdb
 
 import (
 	"database/sql"
-	"time"
 )
 
 type CrawledNode struct {
@@ -16,9 +15,10 @@ type CrawledNode struct {
 	ForkID          string
 }
 
-func ReadRecentNodes(db *sql.DB, lastCheck time.Time) ([]CrawledNode, error) {
+func ReadAndDeleteUnseenNodes(db *sql.Tx) ([]CrawledNode, error) {
 	queryStmt := `
-		SELECT
+		DELETE FROM nodes
+		RETURNING
 			ID,
 			Now,
 			ClientType,
@@ -27,10 +27,8 @@ func ReadRecentNodes(db *sql.DB, lastCheck time.Time) ([]CrawledNode, error) {
 			NetworkID,
 			Country,
 			ForkID
-		FROM nodes
-		WHERE Now > ?
 	`
-	rows, err := db.Query(queryStmt, lastCheck.String())
+	rows, err := db.Query(queryStmt)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the crawler is left running for a long time, the crawler database can get quite large. I have been running this on a $5/m VM, and it got to the point after a day or two where it locked up because the crawler database was too big to process in a reasonable amount of time.

The solution is to delete all the data from the crawler database every time we upsert the api database.

Along with #44, the crawler database stays very small and can be processed in less than a second. This change has been running on my [setup](https://node-crawler.s3fe.io) for over a week and it hasn't had any issues. Resource usage has been hovering around 0.125 load average, and 160MB for both the API and crawler.

Depends on #44 and #45