### PR TITLE
Refactor fmt.println with geth logger in API

### DIFF
--- a/cmd/crawler/api.go
+++ b/cmd/crawler/api.go
@@ -9,6 +9,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/node-crawler/pkg/api"
 	"github.com/ethereum/node-crawler/pkg/apidb"
 	"github.com/ethereum/node-crawler/pkg/crawlerdb"
@@ -58,7 +59,7 @@ func startAPI(ctx *cli.Context) error {
 		return err
 	}
 	if shouldInit {
-		fmt.Println("DB did not exist, init")
+		log.Info("DB did not exist, init")
 		if err := apidb.CreateDB(nodeDB); err != nil {
 			return err
 		}
@@ -104,7 +105,7 @@ func transferNewNodes(crawlerDB, nodeDB *sql.DB) error {
 			// happen. We will still try again.
 			return fmt.Errorf("error inserting nodes: %w", err)
 		}
-		fmt.Printf("%d nodes inserted\n", len(nodes))
+		log.Info("Nodes inserted", "len", len(nodes))
 	}
 
 	crawlerDBTx.Commit()
@@ -123,7 +124,7 @@ func newNodeDeamon(wg *sync.WaitGroup, crawlerDB, nodeDB *sql.DB) {
 	for {
 		err := transferNewNodes(crawlerDB, nodeDB)
 		if err != nil {
-			fmt.Printf("error transferring new nodes: %s\n", err)
+			log.Error("Failure in transferring new nodes", "err", err)
 			time.Sleep(retryTimeout)
 			retryTimeout *= 2
 			continue

--- a/pkg/apidb/database.go
+++ b/pkg/apidb/database.go
@@ -2,11 +2,11 @@ package apidb
 
 import (
 	"database/sql"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/node-crawler/pkg/crawlerdb"
 	"github.com/ethereum/node-crawler/pkg/vparser"
 )
@@ -39,7 +39,7 @@ func CreateDB(db *sql.DB) error {
 }
 
 func InsertCrawledNodes(db *sql.DB, crawledNodes []crawlerdb.CrawledNode) error {
-	fmt.Printf("Writing nodes to db: %v\n", len(crawledNodes))
+	log.Info("Writing nodes to db", "len", len(crawledNodes))
 
 	tx, err := db.Begin()
 	if err != nil {
@@ -121,7 +121,7 @@ func InsertCrawledNodes(db *sql.DB, crawledNodes []crawlerdb.CrawledNode) error 
 }
 
 func DropOldNodes(db *sql.DB, minTimePassed time.Duration) error {
-	fmt.Printf("Dropping all nodes older than: %v\n", minTimePassed)
+	log.Info("Dropping nodes", "older than", minTimePassed)
 	oldest := time.Now().Add(-minTimePassed)
 	tx, err := db.Begin()
 	if err != nil {
@@ -136,6 +136,6 @@ func DropOldNodes(db *sql.DB, minTimePassed time.Duration) error {
 		return err
 	}
 	affected, _ := res.RowsAffected()
-	fmt.Printf("Dropped %v nodes\n", affected)
+	log.Info("Nodes drop", "affected", affected)
 	return tx.Commit()
 }


### PR DESCRIPTION
Replace `fmt.println` with geth logger in API files.

Depends on #42