### PR TITLE
pkg/crawler: respect nodeURL query interval

### DIFF
--- a/pkg/crawler/handshake.go
+++ b/pkg/crawler/handshake.go
@@ -173,6 +173,7 @@ func getStatus(config *params.ChainConfig, version uint32, genesis ethCommon.Has
 
 		_status.Head = header.Hash()
 		_status.ForkID = forkid.NewID(config, genesis, header.Number.Uint64(), header.Time)
+		lastStatusUpdate = time.Now()
 	}
 
 	return _status


### PR DESCRIPTION
`lastStatusUpdate` was not assigned before,
so the remote nodeURL was
queried each time instead of
respecting the 15s interval.

Date: 2023-11-11 11:14:31-07:00